### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: SmallRye Module Info Build
+name: Build StAXMapper
 
 on:
   push:
@@ -11,15 +11,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: build with JDK 11
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: checkout
-
-      - uses: AdoptOpenJDK/install-jdk@v1
-        name: set up JDK 11
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          version: 11
-
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
       - name: Build
-        run: mvn -B install --file pom.xml
+        run: mvn -B install --file pom.xml -P coverage
+      - name: Upload code coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco
+          path: target/site/jacoco

--- a/pom.xml
+++ b/pom.xml
@@ -93,4 +93,58 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.10</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <phase>generate-test-resources</phase>
+                            </execution>
+                           <execution>
+                               <id>report</id>
+                               <phase>prepare-package</phase>
+                               <goals>
+                                   <goal>report</goal>
+                               </goals>
+                           </execution>
+                           <execution>
+                               <id>merge</id>
+                               <goals>
+                                   <goal>merge</goal>
+                               </goals>
+                               <configuration>
+                                   <fileSets>
+                                       <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
+                                           <directory>.</directory>
+                                           <includes>
+                                               <include>**/*.exec</include>
+                                           </includes>
+                                       </fileSet>
+                                   </fileSets>
+                               </configuration>
+                           </execution>
+                           <execution>
+                               <id>aggregate-report</id>
+                               <phase>verify</phase>
+                               <goals>
+                                   <goal>report-aggregate</goal>
+                               </goals>
+                           </execution>
+                       </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Run the GitHub action with the `coverage` profile
to generate a code coverage report in target/site/jacoco and associate it to the GH Action runs